### PR TITLE
fix: correct dehumidifier key spelling

### DIFF
--- a/custom_components/ganjos/const.py
+++ b/custom_components/ganjos/const.py
@@ -186,7 +186,7 @@ AREA_SETTINGS_SWITCH_PARAMETERS = {
     "Light-Dimmable": {"icon": "mdi:brightness-6", "default": False},
     "Exhaust-Available": {"icon": "mdi:fan", "default": False},
     "Exhaust-Dimmable": {"icon": "mdi:fan-speed-3", "default": False},
-    "Exhaust-Equals-Dehumidifer": {"icon": "mdi:fan-minus", "default": False},
+    "Exhaust-Equals-Dehumidifier": {"icon": "mdi:fan-minus", "default": False},
     "Exhaust-Equals-Ac": {"icon": "mdi:fan-plus", "default": False},
     "Ventilation-Available": {"icon": "mdi:air-filter", "default": False},
     "Ventilation-Dimmable": {"icon": "mdi:air-purifier", "default": False},


### PR DESCRIPTION
## Summary
- fix typo in Exhaust-Equals-Dehumidifier key

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log || tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5cbcac3248325b631d3ed93ac24b6