### PR TITLE
Filter unsupported GanjOS platforms

### DIFF
--- a/custom_components/ganjos/__init__.py
+++ b/custom_components/ganjos/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib.util import find_spec
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import ConfigType
@@ -20,8 +21,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
 
-    # Load platform components
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # Load only supported platform components
+    supported_platforms = [
+        platform
+        for platform in PLATFORMS
+        if find_spec(f"custom_components.ganjos.{platform}")
+    ]
+    await hass.config_entries.async_forward_entry_setups(entry, supported_platforms)
 
     # Register default grow area and plant stages
     await create_new_area(hass, entry, "grow", "Grow")
@@ -34,7 +40,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload GanjOS integration."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    supported_platforms = [
+        platform
+        for platform in PLATFORMS
+        if find_spec(f"custom_components.ganjos.{platform}")
+    ]
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, supported_platforms)
     if unload_ok and DOMAIN in hass.data:
         hass.data[DOMAIN].pop(entry.entry_id, None)
         if not hass.data[DOMAIN]:

--- a/custom_components/ganjos/const.py
+++ b/custom_components/ganjos/const.py
@@ -1,13 +1,21 @@
+from importlib.util import find_spec
+
 DOMAIN = "ganjos"
 
-PLATFORMS = [
+_BASE_PLATFORMS = [
     "number",
-    "sensor",
     "switch",
-    "binary_sensor",
     "select",
     "text",
-    "datetime"
+    "datetime",
+]
+
+_OPTIONAL_PLATFORMS = ["sensor", "binary_sensor"]
+
+PLATFORMS = _BASE_PLATFORMS + [
+    platform
+    for platform in _OPTIONAL_PLATFORMS
+    if find_spec(f"custom_components.ganjos.{platform}")
 ]
 
 PLANT_STAGE_PARAMETERS = {


### PR DESCRIPTION
## Summary
- avoid loading nonexistent sensor platforms by checking module availability
- ensure integration only forwards supported platforms

## Testing
- `pytest`
- `python -m py_compile custom_components/ganjos/{const,__init__}.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce5ab0348325bc7ac38862587b45